### PR TITLE
feat: Emulate error at certain rate

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
 HOST=localhost
 PORT=4000
 DATABASE_URL="file:./dev.db"
+# Error rate value for error emulation.
+ERROR_RATIO=0.01

--- a/src/graphql/EmulatedError.ts
+++ b/src/graphql/EmulatedError.ts
@@ -1,0 +1,15 @@
+const ERROR_RATIO = Number(process.env.ERROR_RATIO) || 0.01;
+
+export function shouldEmulateError() {
+  return Math.random() < ERROR_RATIO;
+}
+
+export class EmulatedError extends Error {
+  constructor() {
+    super(
+      `This is error is emulated one and occurring at certain rate (${
+        ERROR_RATIO * 100
+      }%). Please handle this properly.`
+    );
+  }
+}

--- a/src/graphql/queries/project.ts
+++ b/src/graphql/queries/project.ts
@@ -1,4 +1,5 @@
 import { intArg, nonNull, queryField } from "nexus";
+import { EmulatedError, shouldEmulateError } from "../EmulatedError";
 
 export const project = queryField("project", {
   type: "Project",
@@ -7,6 +8,7 @@ export const project = queryField("project", {
     id: nonNull(intArg({ description: "募集ID" })),
   },
   resolve: async (_root, args, { prisma }) => {
+    if (shouldEmulateError()) throw new EmulatedError();
     const { id } = args;
     const project = prisma.project.findUnique({
       where: { id },

--- a/src/graphql/queries/projects.ts
+++ b/src/graphql/queries/projects.ts
@@ -1,4 +1,5 @@
 import { arg, list, queryField } from "nexus";
+import { EmulatedError, shouldEmulateError } from "../EmulatedError";
 import { ProjectFilterInput } from "../inputs/ProjectFilterInput";
 
 export const projects = queryField("projects", {
@@ -12,6 +13,14 @@ export const projects = queryField("projects", {
     }),
   },
   resolve: async (_root, args, { prisma }) => {
+    // NOTE: Emulate error.
+    // We never write codes like this in production code base of course.
+    // But since it is sample application and prisma does not likely to occur errors, so we want to emulate error.
+    // Actual application can't escape from errors which occurred by various reasons and web frontend application should handle these errors properly.
+    if (shouldEmulateError()) {
+      throw new EmulatedError();
+    }
+
     const projects = await prisma.project.findMany({
       where: {
         title: {


### PR DESCRIPTION
## Why

SQLite を使ったローカル開発だとめったにエラーが起きない。
しかしながら一般的な開発ではエラー発生は回避できない(完全に0にはできない)。
エラーがほとんど起きないことでフロントエンドアプリケーション側でエラーハンドリングのことがおろそかになると良くないので、どうにかエラーが発生するようにしたい。

## What

projects query と project query で一定の確率 (デフォルトだと 1%) でエラーを投げるようにした。
エラーの確率は環境変数 `ERROR_RATE` から変更可能にした。
